### PR TITLE
Add missing legacy plugins page, workflow overview bugfixes.

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -32,7 +32,7 @@
 **** Code Changes
 **** Build Locally
 *** xref:AlternativeWorkflow:ROOT:index.adoc[Shipdriver Templates]
-** Legacy Package Deployment
+** xref:legacy-plugins.adoc[Legacy Plugins Deployment]
 * xref:i18n.adoc[Internationalization]
 * Resources
 ** xref:online_tools.adoc[Online Nmea Tools]

--- a/modules/ROOT/pages/languages.adoc
+++ b/modules/ROOT/pages/languages.adoc
@@ -1,7 +1,7 @@
 = Languages
 
 The overall internationalization system is described in the
-xref:plugin-i18n.adoc[Plugins i18n page].
+xref:i18n.adoc[Plugins i18n page].
 
 Using Weather_routing_pi as an example
 

--- a/modules/ROOT/pages/legacy-plugins.adoc
+++ b/modules/ROOT/pages/legacy-plugins.adoc
@@ -1,0 +1,29 @@
+= Legacy Plugins
+
+The term _Legacy Plugins_ refers to plugins installed without involving the
+Plugin Manager or any other part of the OpenCPN core. This was the only
+way to deploy plugins before the new Plugin Manager in 5.2.2.
+
+Packages are deployed as NSIS installers in Windows, .img packages on
+MacOS and Debian .deb packages on Debian/Ubuntu. There are no flatpak
+legacy plugins. Users installs these packages the same way as OpenCPN
+and other programs are installed.
+
+For visibility, plugin packages are published at
+https://opencpn.org/OpenCPN/info/downloadplugins.html[].
+
+Should there be a need to publish new legacy packages, Pavel (@nohal)
+or Dave (@bdbcat) should be contacted so the information at
+opencpn.org can be updated. The xref:plugin_guidelines.adoc[rules]
+described for modern plugins applies also for legacy ones.
+
+Both the xref:managed-plugins:ROOT:index.adoc[Shipdriver] and the
+xref:pm-tp-template.adoc[Testplugin] templates supports creation of
+legacy packages.
+
+Legacy plugins are installed in system directories which typically are
+read-only for regular users. For this reason, installation requires
+root or administrator privileges.
+
+The Plugin Manager installs plugins in directories which could be modified
+by a regular users. Legacy plugins are listed, but cannot be modified.

--- a/modules/ROOT/pages/pm-overview-workflow.adoc
+++ b/modules/ROOT/pages/pm-overview-workflow.adoc
@@ -1,42 +1,44 @@
 = Plugin Manager Workflow Overview
 
- Github --> CircleCI  --> Cloudsmith --> Library
-  Code       Build          Deploy       Catalog
+The Plugin Manager (PM) Workflow described in
+xref:pm-overview-deployment.adoc[Deployment overview] requires plugin vendors to provide
+a plugin tarball downloadable from an URL. A metadata file containing said URL, name,
+version, etc. must also be created.
 
-The Plugin Manager (PM) Workflow described in xref:pm-overview-deployment.adoc[Deployment overview]
-requires plugin vendors to provide:
+These files must be provided separately for each of the plugin build environments. 
+An environment is the combinataion of operating system, version  and hardware for example
+Debian/11/aarch64 or Flatpak/18.08/x86_64. It is easiest to configure a Continuous
+Integration (CI) setup for every build which:
 
-
-* A plugin tarball, downloadable from an URL.
-* A metadata file contain said URL, name, versions, etc.
-
-These files must be provided separately for each of the intended plugin build environments (IE OS compiled).
-It is easiest to configure a Continuous Integration (CI) setup for every build which:
-
-* Creates a tarball according to the xref:plugin-installer:ROOT:Tarballs.adoc[specifications].
-* Uploads the compressed tarball to a public site where it can be downloaded by the user.
-* Creates a metadata (xml) file according to the xref:plugin-installer:ROOT:Catalog.adoc[specifications] containing correct tarball download URL and other plugin data.
+* Creates a tarball according to
+  the xref:plugin-installer:ROOT:Tarballs.adoc[specifications].
+* Uploads the tarball to a public site where it can be downloaded by the user.
+* Creates a metadata (xml) file according to the
+  xref:plugin-installer:ROOT:Catalog.adoc[specifications] containing correct tarball
+  download URL and other plugin data.
 
 Most plugins use one of the templates below to establish the Plugin Manager system:
 
 * xref:managed-plugins:ROOT:index.adoc[Shipdriver]
 * xref:pm-tp-template.adoc[Testplugin]
 
-Testplugin workflow is the most commonly used, partly because it has been around for awhile (recently updated and maintained). Typical settings for plugin and maintenance are located conveniently in the CMakeLists.txt fiie
+Testplugin workflow is the most commonly used, partly because it has been around for
+awhile).
 
-Shipdriver workflow is an updated variant, with some new functionality and a lot of simplifications.
+Shipdriver workflow is an updated variant, with some new functionality and a lot of
+simplifications.
 
 Both frameworks use the same free opensource cloud services:
 
- Github --> CircleCI  --> Cloudsmith --> Library
-  Code       Build          Deploy       Catalog
-
 * Github for plugin source repository
-* Cloudsmith for public storage of binary artifacts, notably tarballs, metadata and packages.
-* CircleCI, Appveyor, Drone.io and Github Actions to build (not all builders are used everywhere).
+* Cloudsmith for public storage of binary artifacts, notably tarballs, metadata and
+  packages.
+* CircleCI, Appveyor, Drone.io and Github Actions to build (not all builders are used
+  everywhere).
 * Travis.com to build, fading due to canceled free open-source options.
 
 The setup of these services is also very similar, but there are differences.
 For a good conceptual graphic see xref:pm-overview-deployment.adoc[Deployment overview]
 
-For Prerequisites see xref:pm-overview-prerequisite.adoc[Prerequisite Overview] and xref:pm-overview-prereq-services.adoc[Prerequisite Services]
+For Prerequisites see xref:pm-overview-prerequisite.adoc[Prerequisite Overview] and
+xref:pm-overview-prereq-services.adoc[Prerequisite Services]


### PR DESCRIPTION
The workflow overview contains some ascii art which is plain
wrong. Drop for now, and enhance/cleanuo some wordings.

Add missing page on legacy plugins.