### PR TITLE
Move plugin build files -> Resources (#54).

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -41,9 +41,9 @@
 * xref:i18n.adoc[Internationalization]
 * Resources
 ** xref:online_tools.adoc[Online Nmea Tools]
+** xref:prebuilt_build_files.adoc[Prebuilt Build Files]
 * xref:manual-maint.adoc[Maintenance of this Manual]
 * Legacy Plugin Packaging
-** xref:plugin_build_files.adoc[Plugin Build Files]
 ** xref:standalone_plugin_compilation.adoc[Plugin Compilation Win]
 ** xref:compiling_external_plugins_and_building_install_packages.adoc[Compile Plugins and build Install Packages]
 ** xref:compiling_plugins_to_debug.adoc[Compile Plugins for Debugging]
@@ -52,7 +52,6 @@
 ** xref:demo_plugin.adoc[Demonstration Plugin]
 ** xref:updating_the_user_manual.adoc[Updating the User Manual]
 ** xref:bug_and_feature_tracking.adoc[Bugs and feature tracking]
-** xref:plugin_build_files.adoc[Plugin Build Files]
 ** xref:troubleshooting_plugins.adoc[Troubleshooting Plugins]
 ** xref:plugin_submissions.adoc[Plugin Submissions]
 ** Redundant

--- a/modules/ROOT/pages/prebuilt_build_files.adoc
+++ b/modules/ROOT/pages/prebuilt_build_files.adoc
@@ -1,11 +1,14 @@
-= Plugin Build Files
+= Prebuilt  Build Files
 
-The links to download pre-built build dependencies can become
+The project publishes some prebuilt resources which are used
+when building both the OpenCPN core and in plugin builds.
+
+The links to these pre-built build dependencies can become
 broken/changed occasionally (such as after CDN closed their sponsorship
-program). These are the available and current Build File links for use
-compilation.
+program). When they do, please update this list.
 
-. Packages.dmg for macOS can be installed using brew:
+
+- Packages.dmg for macOS can be installed using brew:
 https://github.com/OpenCPN/OpenCPN/blob/master/ci/generic-build-macos.sh[https:__github.com/OpenCPN/OpenCPN/blob/master/ci/generic-build-macos.sh]]
 - wxWidgets for macOS, wx312B_opencpn50_macos109.tar.xz:
 https:__download.opencpn.org/s/rwoCNGzx6G34tbC/download[]
@@ -13,8 +16,3 @@ https:__download.opencpn.org/s/rwoCNGzx6G34tbC/download[]
 https:__download.opencpn.org/s/54HsBDLNzRZLL6i/download[]
 - wxWidgets for msWindows, wxWidgets-3.1.2.7z:
 https:__download.opencpn.org/s/E2p4nLDzeqx4SdX/download[]
-
-When these file locations change, please update this list.
-
-Brief Build instructions for Windows, MacOS, Debian, Flatpak
-https://github.com/bdbcat/oesenc_pi/blob/master/INSTALL.md[]


### PR DESCRIPTION
The Plugin Build Files page is actually not only about plugins,
these files are used when buildingalso the core. Also,
the current location under Legacy Plugins makes no sense, it's
used in all sorts of plugin builds.

Move it to Resources. This place is where we collect various,
valuable links, and this is indeed such a case.