### PR TITLE
Clean up plugins chapter (#51)

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -14,19 +14,18 @@
 ** xref:od-code-formatting.adoc[Code Formatting]
 ** xref:od-user-interface-styling.adoc[User Interface Styling]
 ** xref:od-troubleshooting.adoc[Troubleshooting]
-* Plugin Manager Development
+* Plugin Development
 ** xref:pm-plugin-guidelines.adoc[Plugin Guidelines]
 *** xref:pm-plugin-documentation.adoc[Documentation]
 *** xref:pm-plugin-dependencies.adoc[Dependencies]
 ** xref:pm-plugin-api-versions.adoc[Plugin API and ABI]
-* Plugin Manager Workflow
 ** xref:pm-overview-deployment.adoc[Deployment overview]
-** xref:pm-overview-prereq-workflow.adoc[Workflow Prerequisites]
-** xref:pm-overview-prereq-services.adoc[Prerequisite Services]
-** xref:pm-overview-prereq-other.adoc[Cloudsmith Setup]
 ** xref:pm-overview-workflow.adoc[Workflow overview]
 ** xref:pm-tp-template.adoc[Testplugin Template]
-*** xref:pm-tp-system-structure.adoc[System Structure]
+*** xref:pm-overview-prereq-workflow.adoc[Workflow Prerequisites]
+*** xref:pm-overview-prereq-services.adoc[Prerequisite Services]
+*** xref:pm-overview-prereq-other.adoc[Cloudsmith Setup]
+**** xref:pm-tp-system-structure.adoc[System Structure]
 *** xref:pm-tp-dev-setup.adoc[Developer Setup]
 *** xref:pm-tp-config-template.adoc[Configure Template]
 *** Build Locally

--- a/modules/ROOT/pages/pm-overview-deployment.adoc
+++ b/modules/ROOT/pages/pm-overview-deployment.adoc
@@ -1,7 +1,10 @@
-= Plugin Manager Deployment Overview
+= Plugin Deployment Overview
 
 The Plugin Manager (PM) installer is, from 5.2.0 the normal way to
-install plugins. The installer is designed around some concepts:
+install plugins. Prior to 5.2.2 plugins was deployed as operating
+system packages, see xref:dm-legacy-plugins.adoc[Legacy Plugins]
+
+The PM installer is designed around some concepts:
 
 Tarball::
 A tarball is (in this context) the complete plugin which the installer


### PR DESCRIPTION
Order all plugin stuff under the "Plugin Development" header.
This means that we have two top-level chapters "OpenCPN Development"
and "Plugin Development" which is consistent.

The Plugin Development is re-arranged in a simple, logical order
where all details are pushed to testplugin and shipdriver parts.
This enhances readability since there is less clutter in the
overall description. It also make maintenance easier, since
the Testplugin and Shipdriver chapter can be maintained by
those with knowledge about each specific part.